### PR TITLE
Fix "Payload file does not exist" error when referencing as a DLL.

### DIFF
--- a/Store.Dicom/Store.DICOM.csproj
+++ b/Store.Dicom/Store.DICOM.csproj
@@ -720,12 +720,12 @@
     <Compile Include="Store\Dicom\Log\MetroLogManager.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="..\DICOM\Dictionaries\DICOM Dictionary.xml">
+    <EmbeddedResource Include="..\DICOM\Dictionaries\DICOM Dictionary.xml">
       <Link>Dictionaries\DICOM Dictionary.xml</Link>
-    </Content>
-    <Content Include="..\DICOM\Dictionaries\Private Dictionary.xml">
+    </EmbeddedResource>
+    <EmbeddedResource Include="..\DICOM\Dictionaries\Private Dictionary.xml">
       <Link>Dictionaries\Private Dictionary.xml</Link>
-    </Content>
+    </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="..\DICOM\Dictionaries\DICOM Dictionary.xml.gz">


### PR DESCRIPTION
Hi Anders,
I was getting these compile errors when adding Store.DICOM as a DLL from my project:

> Payload file 'C:\Users\Diego\Projetos\experiments\fo-dicom\Store.Dicom\bin\x86\Debug\Dicom\Dictionaries\DICOM Dictionary.xml' does not exist.
> Payload file 'C:\Users\Diego\Projetos\experiments\fo-dicom\Store.Dicom\bin\x86\Debug\Dicom\Dictionaries\Private Dictionary.xml' does not exist.

This seems to be related to the the Windows Store deployment model, maybe combined with some buggy behavior in VS: ["Payload file does not exist" compile error](http://social.msdn.microsoft.com/Forums/windowsapps/en-US/51111470-8a86-44d4-acb8-e268afa7564e/payload-file-does-not-exist-compile-error?forum=winappswithcsharp).
Adding the Dictionary XML files as Embedded Resources fixed this for me, so I'm adding this pull request in hope that it may help others.
Best regards,
Diego
